### PR TITLE
fix: Remove the depends with kms module

### DIFF
--- a/modules/base-data-ingestion/kms.tf
+++ b/modules/base-data-ingestion/kms.tf
@@ -71,7 +71,7 @@ resource "google_project_service_identity" "dataflow_sa" {
 
 module "cmek" {
   source  = "terraform-google-modules/kms/google"
-  version = "~> 2.0"
+  version = "~> 2.0.1"
 
   project_id         = var.data_governance_project_id
   location           = var.cmek_location

--- a/modules/base-data-ingestion/main.tf
+++ b/modules/base-data-ingestion/main.tf
@@ -36,12 +36,6 @@ module "data_ingest_bucket" {
   labels = {
     "enterprise_data_ingest_bucket" = "true"
   }
-
-  # depends_on needed to wait for the KMS roles
-  # to be granted to the Storage Service Account.
-  depends_on = [
-    module.cmek
-  ]
 }
 
 //pub/sub ingest topic
@@ -53,11 +47,6 @@ module "data_ingest_topic" {
   topic                  = "tpc-data-ingest-${random_id.suffix.hex}"
   topic_kms_key_name     = module.cmek.keys[local.ingestion_key_name]
   message_storage_policy = { allowed_persistence_regions : [var.region] }
-  # depends_on needed to wait for the KMS roles
-  # to be granted to the PubSub Service Account.
-  depends_on = [
-    module.cmek
-  ]
 }
 
 //BigQuery dataset
@@ -77,10 +66,4 @@ module "bigquery_dataset" {
     purpose  = "ingest"
     billable = "true"
   }
-
-  # depends_on needed to wait for the KMS roles
-  # to be granted to the Bigquery Service Account.
-  depends_on = [
-    module.cmek
-  ]
 }

--- a/modules/base-data-ingestion/vpc_service_control.tf
+++ b/modules/base-data-ingestion/vpc_service_control.tf
@@ -49,7 +49,6 @@ module "dwh_networking" {
   depends_on = [
     module.data_ingest_bucket,
     module.bigquery_dataset,
-    module.data_ingest_topic,
-    module.cmek
+    module.data_ingest_topic
   ]
 }


### PR DESCRIPTION
Fixes #58

Changed the version of kms to remove the necessity to used a depends_on in kms modules that need some grants.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
