### PR TITLE
Moves de-identifcation-template build step outside base-data-ingestion

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 3600s
+timeout: 10800s
 steps:
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,7 +15,7 @@
 ---
 driver:
   name: terraform
-  command_timeout: 2700
+  command_timeout: 3600
   verify_version: false
 
 provisioner:


### PR DESCRIPTION
Fixes #62 partially


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
