### PR TITLE
Examples/de_identification_template module: Variable and output description consistency

### DIFF
--- a/examples/de_identification_template/README.md
+++ b/examples/de_identification_template/README.md
@@ -11,7 +11,7 @@ The `crypto_key` location must be the same location used for the `dlp_location`.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | crypto\_key | The full resource name of the Cloud KMS key that wraps the data crypto key used by DLP. | `string` | n/a | yes |
-| dataflow\_service\_account | The Service Account email that will be used to identify the VMs in which the jobs are running | `string` | n/a | yes |
+| dataflow\_service\_account | The Service Account email that will be used to identify the VMs in which the jobs are running. | `string` | n/a | yes |
 | dlp\_location | The location of DLP resources. See https://cloud.google.com/dlp/docs/locations. The 'global' KMS location is valid. | `string` | `"global"` | no |
 | project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
 | terraform\_service\_account | The email address of the service account that will run the Terraform config. | `string` | n/a | yes |

--- a/examples/de_identification_template/variables.tf
+++ b/examples/de_identification_template/variables.tf
@@ -41,6 +41,6 @@ variable "wrapped_key" {
 }
 
 variable "dataflow_service_account" {
-  description = "The Service Account email that will be used to identify the VMs in which the jobs are running"
+  description = "The Service Account email that will be used to identify the VMs in which the jobs are running."
   type        = string
 }


### PR DESCRIPTION
Helps to fixes #36

This pr fixed and made consistente the variable and outputs declaration files in the `de_identification_template` module in the examples.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
