### PR TITLE
Examples/regional-dlp module: Variable and output description consistency

### DIFF
--- a/examples/regional-dlp/README.md
+++ b/examples/regional-dlp/README.md
@@ -210,7 +210,7 @@ If your user does not have the necessary roles to run the commands above you can
 | Name | Description |
 |------|-------------|
 | dataflow\_bucket\_name | The name of the bucket created to store Dataflow temporary data. |
-| dataflow\_controller\_service\_account\_email | The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account |
+| dataflow\_controller\_service\_account\_email | The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account. |
 | templates\_bucket\_name | The name of the bucket created to store the flex template. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/regional-dlp/output.tf
+++ b/examples/regional-dlp/output.tf
@@ -25,6 +25,6 @@ output "templates_bucket_name" {
 }
 
 output "dataflow_controller_service_account_email" {
-  description = "The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account"
+  description = "The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account."
   value       = module.data_ingestion.dataflow_controller_service_account_email
 }

--- a/examples/regional-dlp/variables.tf
+++ b/examples/regional-dlp/variables.tf
@@ -20,8 +20,8 @@ variable "org_id" {
 }
 
 variable "access_context_manager_policy_id" {
-  type        = number
   description = "The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
+  type        = number
 }
 
 variable "project_id" {


### PR DESCRIPTION
Helps to fixes #36

This pr fixed and made consistente the variable and outputs declaration files in the `regional-dlp` module in the examples.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
