### PR TITLE
Modules/org_policies module: Variable and output description consistency

### DIFF
--- a/modules/org_policies/variables.tf
+++ b/modules/org_policies/variables.tf
@@ -30,7 +30,7 @@ variable "trusted_subnetwork" {
 }
 
 variable "trusted_locations" {
-  description = "This is a list of trusted regions where location-based GCP resources can be created. ie us-locations eu-locations"
+  description = "This is a list of trusted regions where location-based GCP resources can be created. ie us-locations eu-locations."
   type        = list(string)
   default     = ["us-locations", "eu-locations"]
 }


### PR DESCRIPTION
Helps to fixes #36

This pr fixed and made consistente the variable and outputs declaration files in the `org_policies` module.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
