### PR TITLE
Fixtures/bigquery-sensitive-data module: Variable and output description consistency

### DIFF
--- a/test/fixtures/bigquery-sensitive-data/variables.tf
+++ b/test/fixtures/bigquery-sensitive-data/variables.tf
@@ -15,6 +15,6 @@
  */
 
 variable "project_id" {
-  description = "Project where the dataset and table are created"
+  description = "Project where the dataset and table are created."
   type        = string
 }


### PR DESCRIPTION
Helps to fixes #36

This pr fixed and made consistente the variable and outputs declaration files in the `bigquery-sensitive-data` module.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
