### PR TITLE
Fixtures/regional-dlp module: Variable and output description consistency

### DIFF
--- a/test/fixtures/regional-dlp/output.tf
+++ b/test/fixtures/regional-dlp/output.tf
@@ -35,6 +35,6 @@ output "templates_bucket_name" {
 }
 
 output "dataflow_controller_service_account_email" {
-  description = "The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account"
+  description = "The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account."
   value       = module.regional_dlp_example.dataflow_controller_service_account_email
 }

--- a/test/fixtures/regional-dlp/variables.tf
+++ b/test/fixtures/regional-dlp/variables.tf
@@ -30,6 +30,6 @@ variable "project_id" {
 }
 
 variable "access_context_manager_policy_id" {
-  type        = number
   description = "The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
+  type        = number
 }


### PR DESCRIPTION
Helps to fixes #36

This pr fixed and made consistente the variable and outputs declaration files in the `regional-dlp` module.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
