### PR TITLE
add new services to the perimeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ module "secured_data_warehouse" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`. | `number` | n/a | yes |
+| additional\_restricted\_services | The list of additional Google services to be protected by the VPC-SC service perimeters. | `list(string)` | `[]` | no |
 | bucket\_class | The storage class for the bucket being provisioned. | `string` | `"STANDARD"` | no |
 | bucket\_lifecycle\_rules | List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches\_storage\_class should be a comma delimited string. | <pre>set(object({<br>    action    = any<br>    condition = any<br>  }))</pre> | <pre>[<br>  {<br>    "action": {<br>      "type": "Delete"<br>    },<br>    "condition": {<br>      "age": 30,<br>      "matches_storage_class": [<br>        "STANDARD"<br>      ],<br>      "with_state": "ANY"<br>    }<br>  }<br>]</pre> | no |
 | bucket\_name | The name of for the bucket being provisioned. | `string` | n/a | yes |

--- a/service_control.tf
+++ b/service_control.tf
@@ -29,6 +29,26 @@ locals {
   perimeter_members_confidential = distinct(concat([
     "serviceAccount:${var.terraform_service_account}"
   ], var.perimeter_additional_members))
+
+  base_restricted_services = [
+    "bigquery.googleapis.com",
+    "cloudasset.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudkms.googleapis.com",
+    "compute.googleapis.com",
+    "datacatalog.googleapis.com",
+    "dataflow.googleapis.com",
+    "dlp.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "pubsub.googleapis.com",
+    "secretmanager.googleapis.com",
+    "sts.googleapis.com",
+    "iam.googleapis.com",
+    "storage.googleapis.com"
+  ]
+
+  restricted_services = distinct(concat(local.base_restricted_services, var.additional_restricted_services))
 }
 
 data "google_project" "data_ingestion_project" {
@@ -74,23 +94,7 @@ module "data_ingestion_vpc_sc" {
   common_suffix                    = random_id.suffix.hex
   resources                        = [data.google_project.data_ingestion_project.number, data.google_project.non_confidential_data_project.number]
   perimeter_members                = local.perimeter_members_data_ingestion
-  restricted_services = [
-    "bigquery.googleapis.com",
-    "cloudasset.googleapis.com",
-    "cloudfunctions.googleapis.com",
-    "cloudkms.googleapis.com",
-    "compute.googleapis.com",
-    "datacatalog.googleapis.com",
-    "dataflow.googleapis.com",
-    "dlp.googleapis.com",
-    "logging.googleapis.com",
-    "monitoring.googleapis.com",
-    "pubsub.googleapis.com",
-    "secretmanager.googleapis.com",
-    "sts.googleapis.com",
-    "iam.googleapis.com",
-    "storage.googleapis.com"
-  ]
+  restricted_services              = local.restricted_services
 
   sdx_egress_rule = [
     {
@@ -122,23 +126,7 @@ module "data_governance_vpc_sc" {
   common_suffix                    = random_id.suffix.hex
   resources                        = [data.google_project.governance_project.number]
   perimeter_members                = local.perimeter_members_governance
-  restricted_services = [
-    "bigquery.googleapis.com",
-    "cloudasset.googleapis.com",
-    "cloudfunctions.googleapis.com",
-    "cloudkms.googleapis.com",
-    "compute.googleapis.com",
-    "datacatalog.googleapis.com",
-    "dataflow.googleapis.com",
-    "dlp.googleapis.com",
-    "logging.googleapis.com",
-    "monitoring.googleapis.com",
-    "pubsub.googleapis.com",
-    "secretmanager.googleapis.com",
-    "sts.googleapis.com",
-    "iam.googleapis.com",
-    "storage.googleapis.com"
-  ]
+  restricted_services              = local.restricted_services
 
   # depends_on needed to prevent intermittent errors
   # when the VPC-SC is created but perimeter member
@@ -158,23 +146,7 @@ module "confidential_data_vpc_sc" {
   common_suffix                    = random_id.suffix.hex
   resources                        = [data.google_project.confidential_project.number]
   perimeter_members                = local.perimeter_members_confidential
-  restricted_services = [
-    "bigquery.googleapis.com",
-    "cloudasset.googleapis.com",
-    "cloudfunctions.googleapis.com",
-    "cloudkms.googleapis.com",
-    "compute.googleapis.com",
-    "datacatalog.googleapis.com",
-    "dataflow.googleapis.com",
-    "dlp.googleapis.com",
-    "logging.googleapis.com",
-    "monitoring.googleapis.com",
-    "pubsub.googleapis.com",
-    "secretmanager.googleapis.com",
-    "sts.googleapis.com",
-    "iam.googleapis.com",
-    "storage.googleapis.com"
-  ]
+  restricted_services              = local.restricted_services
 
   sdx_egress_rule = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -194,3 +194,9 @@ variable "kms_key_protection_level" {
   type        = string
   default     = "HSM"
 }
+
+variable "additional_restricted_services" {
+  description = "The list of additional Google services to be protected by the VPC-SC service perimeters."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Fixes #144

Added two services:

- sts.googleapis.com
- iam.googleapis.com

Secret Manager service not removed because it is now been used in the blueprint.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
