### PR TITLE
Added ignore resources in the ignore_changes of the perimeter creation

### DIFF
--- a/modules/dwh-vpc-sc/main.tf
+++ b/modules/dwh-vpc-sc/main.tf
@@ -66,7 +66,6 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
 
   status {
     restricted_services = var.restricted_services
-    resources           = formatlist("projects/%s", var.resources)
     access_levels = formatlist(
       "accessPolicies/${local.actual_policy}/accessLevels/%s",
       [module.access_level_policy.name]
@@ -92,6 +91,12 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
       }
     }
   }
+}
+
+resource "google_access_context_manager_service_perimeter_resource" "service-perimeter-resource" {
+  for_each       = var.resources
+  perimeter_name = google_access_context_manager_service_perimeter.regular_service_perimeter.name
+  resource       = "projects/${each.value}"
 }
 
 resource "time_sleep" "wait_for_vpc_sc_propagation" {

--- a/modules/dwh-vpc-sc/variables.tf
+++ b/modules/dwh-vpc-sc/variables.tf
@@ -26,8 +26,7 @@ variable "project_id" {
 
 variable "resources" {
   description = "A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed."
-  type        = list(string)
-  default     = []
+  type        = map(string)
 }
 
 variable "common_suffix" {

--- a/service_control.tf
+++ b/service_control.tf
@@ -30,6 +30,19 @@ locals {
     "serviceAccount:${var.terraform_service_account}"
   ], var.perimeter_additional_members))
 
+  data_ingestion_vpc_sc_resources = {
+    data_ingestion   = data.google_project.data_ingestion_project.number
+    non_confidential = data.google_project.non_confidential_data_project.number
+  }
+
+  data_governance_vpc_sc_resources = {
+    governance = data.google_project.governance_project.number
+  }
+
+  confidential_data_vpc_sc_resources = {
+    confidential = data.google_project.confidential_project.number
+  }
+
   base_restricted_services = [
     "bigquery.googleapis.com",
     "cloudasset.googleapis.com",
@@ -92,7 +105,7 @@ module "data_ingestion_vpc_sc" {
   access_context_manager_policy_id = var.access_context_manager_policy_id
   common_name                      = "data_ingestion"
   common_suffix                    = random_id.suffix.hex
-  resources                        = [data.google_project.data_ingestion_project.number, data.google_project.non_confidential_data_project.number]
+  resources                        = local.data_ingestion_vpc_sc_resources
   perimeter_members                = local.perimeter_members_data_ingestion
   restricted_services              = local.restricted_services
 
@@ -124,7 +137,7 @@ module "data_governance_vpc_sc" {
   access_context_manager_policy_id = var.access_context_manager_policy_id
   common_name                      = "data_governance"
   common_suffix                    = random_id.suffix.hex
-  resources                        = [data.google_project.governance_project.number]
+  resources                        = local.data_governance_vpc_sc_resources
   perimeter_members                = local.perimeter_members_governance
   restricted_services              = local.restricted_services
 
@@ -144,7 +157,7 @@ module "confidential_data_vpc_sc" {
   access_context_manager_policy_id = var.access_context_manager_policy_id
   common_name                      = "confidential_data"
   common_suffix                    = random_id.suffix.hex
-  resources                        = [data.google_project.confidential_project.number]
+  resources                        = local.confidential_data_vpc_sc_resources
   perimeter_members                = local.perimeter_members_confidential
   restricted_services              = local.restricted_services
 


### PR DESCRIPTION
We started [this discussion in the pull request](https://github.com/GoogleCloudPlatform/terraform-google-secured-data-warehouse/pull/189#pullrequestreview-818037189) #189 

I added `ignore_changes` with `resources` on the `google_access_context_manager_service_perimeter` resource, so that user could add other projects to the perimeters. 

The foundation has a similar solution for the same issue:

https://github.com/terraform-google-modules/terraform-example-foundation/blob/1fad10b2af93069a7369cd100a3fcf2cddaa6f74/3-networks/modules/restricted_shared_vpc/service_control.tf#L59
```hcl
resource "google_access_context_manager_service_perimeter" "regular_service_perimeter" {
  ...
  lifecycle {
    ignore_changes = [status[0].resources]
  }
}
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
