### PR TITLE
Add blueprint_type output value to standalone-tutorial

### DIFF
--- a/examples/tutorial-standalone/README.md
+++ b/examples/tutorial-standalone/README.md
@@ -259,6 +259,7 @@ locals {
 
 | Name | Description |
 |------|-------------|
+| blueprint\_type | Type of blueprint this module represents. |
 | confidential\_dataflow\_controller\_service\_account\_email | The confidential project Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account. |
 | data\_ingestion\_bucket\_name | The name of the bucket created for data ingestion pipeline. |
 | data\_ingestion\_topic\_name | The topic created for data ingestion pipeline. |

--- a/examples/tutorial-standalone/outputs.tf
+++ b/examples/tutorial-standalone/outputs.tf
@@ -43,3 +43,8 @@ output "data_ingestion_topic_name" {
   description = "The topic created for data ingestion pipeline."
   value       = module.secured_data_warehouse.data_ingestion_topic_name
 }
+
+output "blueprint_type" {
+  description = "Type of blueprint this module represents."
+  value       = module.secured_data_warehouse.blueprint_type
+}


### PR DESCRIPTION
Adding the blueprint type output value to standalone tutorial module was missed as part of #184 so adding it now.