### PR TITLE
fix: Wrapped-key helper usability review

### DIFF
--- a/helpers/wrapped-key/.gitignore
+++ b/helpers/wrapped-key/.gitignore
@@ -1,0 +1,1 @@
+kms_helper/

--- a/helpers/wrapped-key/README.md
+++ b/helpers/wrapped-key/README.md
@@ -1,7 +1,10 @@
 # Wrapped Key Helper
 
-This helper uses cloudHSM to generate 256 [random bits](https://cloud.google.com/kms/docs/generate-random), which are [wrapped by an encryption key](https://cloud.google.com/kms/docs/encrypt-decrypt) protected by cloudHSM.
+This helper uses [cloudHSM](https://cloud.google.com/kms/docs/hsm#create-a-key) to generate 256 [random bits](https://cloud.google.com/kms/docs/generate-random), which are [wrapped by an encryption key](https://cloud.google.com/kms/docs/encrypt-decrypt) protected by cloudHSM.
 It base64 encodes the output so it can be used in a Cloud DLP de-identification template.
+
+The keyring used for encryption must be in a region that has cloudHSM [available](https://cloud.google.com/kms/docs/locations#regional:).
+This script will be run with the credential configured in the [Cloud SDK](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account) tool.
 
 __Note:__ This helper is mainly for sample purpose. You should use your security team's recommend approach to generate and handle key material properly.
 
@@ -65,8 +68,10 @@ python3 wrapped_key.py \
 OR
 
 ```sh
-export crypto_key_path="projects/PROJECT-ID/locations/LOCATION-ID/keyRings/KEY-RING-ID/cryptoKeys/KEY-ID"
+export crypto_key_path=<crypto-key-path>
 
 python3 wrapped_key.py \
 --crypto_key_path ${crypto_key_path}
 ```
+
+The `crypto-key-path` format is `projects/PROJECT-ID/locations/LOCATION-ID/keyRings/KEY-RING-ID/cryptoKeys/KEY-ID`

--- a/helpers/wrapped-key/wrapped_key.py
+++ b/helpers/wrapped-key/wrapped_key.py
@@ -143,7 +143,6 @@ if __name__ == '__main__':
                         '/keyRings/KEY-RING-ID/cryptoKeys/KEY-ID')
 
     args = parser.parse_args()
-    print(args.crypto_key_path)
     if args.crypto_key_path is not None:
         client = kms.KeyManagementServiceClient()
         key_ring_args = client.parse_crypto_key_path(args.crypto_key_path)
@@ -159,4 +158,4 @@ if __name__ == '__main__':
 
     encrypt_response = encrypt_symmetric(project_id, location_id,
                                          key_ring_id, key_id)
-    print(base64.b64encode(encrypt_response.ciphertext))
+    print(base64.b64encode(encrypt_response.ciphertext).decode("utf-8"))


### PR DESCRIPTION
Fixes partially #37

I made two changes for better usability:
- wrapped-key helper readme review
- The wrapped-key output was `b'BASE_64_VALUE'` and now is `BASE_64_VALUE`


Check list:
- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
