### PR TITLE
fix: Added a necessary role to the Main README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Grant the following roles to the service account.
 - Organization level
   - Access Context Manager Admin: `roles/accesscontextmanager.policyAdmin`
   - Organization Policy Administrator: `roles/orgpolicy.policyAdmin`
+  - Organization Administrator: `roles/resourcemanager.organizationAdmin`
 - Project level:
   - Data ingestion project
     - App Engine Creator:`roles/appengine.appCreator`


### PR DESCRIPTION
Fixes partially #37

We made fix to update the requirement for the roles of the terraform service account to include the organization administrator to be able to grant roles at the organization to the security groups:

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
