### PR TITLE
add VPC Service Controls and Access Context Manager outputs in the simple example

### DIFF
--- a/examples/simple-example/README.md
+++ b/examples/simple-example/README.md
@@ -40,10 +40,14 @@ It uses:
 | cmek\_confidential\_bigquery\_crypto\_key | The Customer Managed Crypto Key for the confidential BigQuery service. |
 | cmek\_data\_ingestion\_crypto\_key | The Customer Managed Crypto Key for the data ingestion crypto boundary. |
 | cmek\_reidentification\_crypto\_key | The Customer Managed Crypto Key for the reidentification crypto boundary. |
-| data\_ingestion\_access\_level\_name | Access context manager access level name. |
+| confidential\_data\_access\_level\_name | Confidential Data Access Context Manager access level name. |
+| confidential\_data\_service\_perimeter\_name | Confidential Data VPC Service Controls service perimeter name |
+| data\_governance\_access\_level\_name | Data Governance Access Context Manager access level name. |
+| data\_governance\_service\_perimeter\_name | Data Governance VPC Service Controls service perimeter name. |
+| data\_ingestion\_access\_level\_name | Data Ingestion Access Context Manager access level name. |
 | data\_ingestion\_bigquery\_dataset | The bigquery dataset created for data ingestion pipeline. |
 | data\_ingestion\_bucket\_name | The name of the bucket created for data ingestion pipeline. |
-| data\_ingestion\_service\_perimeter\_name | Access context manager service perimeter name. |
+| data\_ingestion\_service\_perimeter\_name | Data Ingestion VPC Service Controls service perimeter name. |
 | data\_ingestion\_topic\_name | The topic created for data ingestion pipeline. |
 | dataflow\_controller\_service\_account\_email | The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account. |
 | pubsub\_writer\_service\_account\_email | The PubSub writer service account email. Should be used to write data to the PubSub topics the data ingestion pipeline reads from. |

--- a/examples/simple-example/outputs.tf
+++ b/examples/simple-example/outputs.tf
@@ -44,16 +44,6 @@ output "data_ingestion_bigquery_dataset" {
   value       = module.secured_data_warehouse.data_ingestion_bigquery_dataset
 }
 
-output "data_ingestion_access_level_name" {
-  description = "Access context manager access level name."
-  value       = module.secured_data_warehouse.data_ingestion_access_level_name
-}
-
-output "data_ingestion_service_perimeter_name" {
-  description = "Access context manager service perimeter name."
-  value       = module.secured_data_warehouse.data_ingestion_service_perimeter_name
-}
-
 output "cmek_data_ingestion_crypto_key" {
   description = "The Customer Managed Crypto Key for the data ingestion crypto boundary."
   value       = module.secured_data_warehouse.cmek_data_ingestion_crypto_key
@@ -64,7 +54,6 @@ output "cmek_bigquery_crypto_key" {
   value       = module.secured_data_warehouse.cmek_bigquery_crypto_key
 }
 
-
 output "cmek_reidentification_crypto_key" {
   description = "The Customer Managed Crypto Key for the reidentification crypto boundary."
   value       = module.secured_data_warehouse.cmek_reidentification_crypto_key
@@ -73,6 +62,36 @@ output "cmek_reidentification_crypto_key" {
 output "cmek_confidential_bigquery_crypto_key" {
   description = "The Customer Managed Crypto Key for the confidential BigQuery service."
   value       = module.secured_data_warehouse.cmek_confidential_bigquery_crypto_key
+}
+
+output "data_ingestion_access_level_name" {
+  description = "Data Ingestion Access Context Manager access level name."
+  value       = module.secured_data_warehouse.data_ingestion_access_level_name
+}
+
+output "data_ingestion_service_perimeter_name" {
+  description = "Data Ingestion VPC Service Controls service perimeter name."
+  value       = module.secured_data_warehouse.data_ingestion_service_perimeter_name
+}
+
+output "data_governance_access_level_name" {
+  description = "Data Governance Access Context Manager access level name."
+  value       = module.secured_data_warehouse.data_governance_access_level_name
+}
+
+output "data_governance_service_perimeter_name" {
+  description = "Data Governance VPC Service Controls service perimeter name."
+  value       = module.secured_data_warehouse.data_governance_service_perimeter_name
+}
+
+output "confidential_data_access_level_name" {
+  description = "Confidential Data Access Context Manager access level name."
+  value       = module.secured_data_warehouse.confidential_access_level_name
+}
+
+output "confidential_data_service_perimeter_name" {
+  description = "Confidential Data VPC Service Controls service perimeter name"
+  value       = module.secured_data_warehouse.confidential_service_perimeter_name
 }
 
 output "blueprint_type" {


### PR DESCRIPTION
This PR adds in the simple example outputs for the VPC Service Controls and Access Context Manager outputs of the main module.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
