### PR TITLE
Remove labels from buckets and BigQuery datasets

### DIFF
--- a/modules/confidential-data/main.tf
+++ b/modules/confidential-data/main.tf
@@ -31,11 +31,6 @@ module "dataflow_bucket" {
   encryption = {
     default_kms_key_name = var.cmek_reidentification_crypto_key
   }
-
-  labels = {
-    "dataflow_data_ingestion_bucket" = "true"
-  }
-
 }
 
 module "bigquery_confidential_data" {
@@ -49,5 +44,4 @@ module "bigquery_confidential_data" {
   delete_contents_on_destroy  = var.delete_contents_on_destroy
   encryption_key              = var.cmek_confidential_bigquery_crypto_key
   default_table_expiration_ms = var.dataset_default_table_expiration_ms
-  dataset_labels              = var.dataset_labels
 }

--- a/modules/confidential-data/variables.tf
+++ b/modules/confidential-data/variables.tf
@@ -25,12 +25,6 @@ variable "delete_contents_on_destroy" {
   default     = false
 }
 
-variable "dataset_labels" {
-  description = "Key value pairs in a map for dataset labels."
-  type        = map(string)
-  default     = {}
-}
-
 variable "data_governance_project_id" {
   description = "The ID of the project in which the KMS, Datacatalog, and DLP resources are created."
   type        = string

--- a/modules/data-ingestion/main.tf
+++ b/modules/data-ingestion/main.tf
@@ -33,10 +33,6 @@ module "data_ingestion_bucket" {
   encryption = {
     default_kms_key_name = var.data_ingestion_encryption_key
   }
-
-  labels = {
-    "enterprise_data_ingestion_bucket" = "true"
-  }
 }
 
 module "dataflow_bucket" {
@@ -53,11 +49,6 @@ module "dataflow_bucket" {
   encryption = {
     default_kms_key_name = var.data_ingestion_encryption_key
   }
-
-  labels = {
-    "dataflow_data_ingestion_bucket" = "true"
-  }
-
 }
 
 //pub/sub data ingestion topic
@@ -84,9 +75,4 @@ module "bigquery_dataset" {
   encryption_key              = var.bigquery_encryption_key
   delete_contents_on_destroy  = var.delete_contents_on_destroy
   default_table_expiration_ms = var.dataset_default_table_expiration_ms
-
-  dataset_labels = {
-    purpose  = "data-ingestion"
-    billable = "true"
-  }
 }


### PR DESCRIPTION
Fixes #<issue_number_goes_here>

This PR removes unused labels from Cloud Storage buckets and BigQuery datasets.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
