### PR TITLE
fix: Added instructions about how create the flex template in the examples/dataflow-with-dlp

### DIFF
--- a/examples/dataflow-with-dlp/README.md
+++ b/examples/dataflow-with-dlp/README.md
@@ -13,6 +13,7 @@ It uses:
 1. The [Secured data warehouse](../../README.md#requirements) module requirements to create the Secured data warehouse infrastructure.
 1. A `crypto_key` and `wrapped_key` pair. Contact your Security Team to obtain the pair. The `crypto_key` location must be the same location where DLP, Storage and BigQuery are going to be created (`local.region`). There is a [Wrapped Key Helper](../../helpers/wrapped-key/README.md) python script which generates a wrapped key.
 1. The identity deploying the example must have permission to grant roles `roles/cloudkms.cryptoKeyDecrypter` and `roles/cloudkms.cryptoKeyEncrypter` in the KMS `crypto_key`. It will be granted to the Data ingestion Dataflow worker service account created by the Secured Data Warehouse module.
+1. Pre-build Java Regional DLP De-identification and Re-identification flex templates. See [Flex templates](../../flex-templates/README.md) on how to create them.
 1. The identity deploying the example must have permission to grant role `roles/artifactregistry.reader` in the docker repo of the Flex templates.
 1. A network and subnetwork in the data ingestion project [configured for Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access).
 


### PR DESCRIPTION
Fixes partially #37

I added instructions about how to deploy the flex template in the readme of examples/dataflow-with-dlp .

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
