### PR TITLE
Add an Organization Policy that prevents VM instances with public IPs

### DIFF
--- a/modules/org-policies/compute.tf
+++ b/modules/org-policies/compute.tf
@@ -58,3 +58,13 @@ module "vpc_subnetwork_policy" {
   allow             = var.trusted_subnetworks
   allow_list_length = length(var.trusted_subnetworks)
 }
+
+module "vm_external_ip_access" {
+  source      = "terraform-google-modules/org-policy/google"
+  version     = "~> 4.0"
+  policy_for  = "project"
+  project_id  = var.project_id
+  constraint  = "constraints/compute.vmExternalIpAccess"
+  policy_type = "list"
+  enforce     = "true"
+}


### PR DESCRIPTION
This PR adds an Organization Policy,  `constraints/compute.vmExternalIpAccess`,  that defines allowed external IPs for VM instances. In our case this list is **empty** which prevents the creation of VM instances with public IP Address.

See Organization Policies [Constraints for specific services](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints#constraints-for-specific-services) documentation for additional details.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
