### PR TITLE
Fix: Add route configuration instructions for the network in the regional dlp example

### DIFF
--- a/examples/regional-dlp/README.md
+++ b/examples/regional-dlp/README.md
@@ -32,6 +32,10 @@ It uses:
 - [Restricted gcr.io](https://cloud.google.com/vpc-service-controls/docs/set-up-gke#configure-dns).
 - [Restricted Artifact Registry](https://cloud.google.com/vpc-service-controls/docs/set-up-gke#configure-dns).
 
+### Route configuration
+
+- Static routes configured to *private* and *restricted* IPs. For more information see [Routing options](https://cloud.google.com/vpc/docs/configure-private-google-access#config-routing) in the documentation.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 


### PR DESCRIPTION
Fixes partially #37

Add route configuration instructions for the network in the regional dlp example

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
