### PR TITLE
fix: Change the bytes size in the wrapped_key python script

### DIFF
--- a/helpers/wrapped-key/wrapped_key.py
+++ b/helpers/wrapped-key/wrapped_key.py
@@ -35,7 +35,7 @@ def encrypt_symmetric(project_id, location_id, key_ring_id, key_id):
     """
 
     # Generate random bytes
-    key = generate_random_bytes(project_id, location_id, 32)
+    key = generate_random_bytes(project_id, location_id, 16)
 
     # Encode key to b64
     plaintext_bytes = base64.b64encode(key)


### PR DESCRIPTION
Change the bytes size in the wrapped_key python script.

Allowed values for DLP are 32, 24, and 16. Using the 32 in a python template does not work, changed for 16 works fine.   

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
