### PR TITLE
fix: Fixed the grammar of the exemples variables and outputs

### DIFF
--- a/examples/regional-dlp/README.md
+++ b/examples/regional-dlp/README.md
@@ -56,7 +56,7 @@ It uses:
 | data\_governance\_project\_id | The ID of the project in which the data governance resources will be created. | `string` | n/a | yes |
 | data\_ingestion\_project\_id | The ID of the project in which the data ingestion resources will be created. | `string` | n/a | yes |
 | delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | `bool` | `false` | no |
-| external\_flex\_template\_project\_id | Project id of the external project that host the flex Dataflow templates. | `string` | n/a | yes |
+| external\_flex\_template\_project\_id | Project id of the external project that hosts the flex Dataflow templates. | `string` | n/a | yes |
 | flex\_template\_gs\_path | The Google Cloud Storage gs path to the JSON file built flex template that supports DLP de-identification. | `string` | `""` | no |
 | location | The location of Artifact registry. Run `gcloud artifacts locations list` to list available locations. | `string` | `"us-east4"` | no |
 | network\_administrator\_group | Google Cloud IAM group that reviews network configuration. Typically, this includes members of the networking team. | `string` | n/a | yes |
@@ -74,6 +74,6 @@ It uses:
 
 | Name | Description |
 |------|-------------|
-| template\_full\_path | The full path of DLP de-identification template. |
+| template\_full\_path | The full path of the DLP de-identification template. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/regional-dlp/output.tf
+++ b/examples/regional-dlp/output.tf
@@ -16,6 +16,6 @@
 
 
 output "template_full_path" {
-  description = "The full path of DLP de-identification template."
+  description = "The full path of the DLP de-identification template."
   value       = module.de_identification_template_example.template_full_path
 }

--- a/examples/regional-dlp/variables.tf
+++ b/examples/regional-dlp/variables.tf
@@ -46,7 +46,7 @@ variable "confidential_data_project_id" {
 }
 
 variable "external_flex_template_project_id" {
-  description = "Project id of the external project that host the flex Dataflow templates."
+  description = "Project id of the external project that hosts the flex Dataflow templates."
   type        = string
 }
 

--- a/examples/simple-example/README.md
+++ b/examples/simple-example/README.md
@@ -46,7 +46,7 @@ It uses:
 | data\_governance\_service\_perimeter\_name | Data Governance VPC Service Controls service perimeter name. |
 | data\_ingestion\_access\_level\_name | Data Ingestion Access Context Manager access level name. |
 | data\_ingestion\_bigquery\_dataset | The bigquery dataset created for data ingestion pipeline. |
-| data\_ingestion\_bucket\_name | The name of the bucket created for data ingestion pipeline. |
+| data\_ingestion\_bucket\_name | The name of the bucket created for the data ingestion pipeline. |
 | data\_ingestion\_service\_perimeter\_name | Data Ingestion VPC Service Controls service perimeter name. |
 | data\_ingestion\_topic\_name | The topic created for data ingestion pipeline. |
 | dataflow\_controller\_service\_account\_email | The Dataflow controller service account email. See https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#specifying_a_user-managed_controller_service_account. |

--- a/examples/simple-example/outputs.tf
+++ b/examples/simple-example/outputs.tf
@@ -30,7 +30,7 @@ output "pubsub_writer_service_account_email" {
 }
 
 output "data_ingestion_bucket_name" {
-  description = "The name of the bucket created for data ingestion pipeline."
+  description = "The name of the bucket created for the data ingestion pipeline."
   value       = module.secured_data_warehouse.data_ingestion_bucket_name
 }
 


### PR DESCRIPTION
Fixes #37

Fixed the grammar of some texts that are in the outputs and inputs section of the READMEs in the examples

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
