### PR TITLE
fix: hardcode blueprint type

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -164,5 +164,5 @@ output "cmek_confidential_bigquery_crypto_key" {
 
 output "blueprint_type" {
   description = "Type of blueprint this module represents."
-  value       = local.blueprint_type
+  value       = "blueprints/terraform/terraform-google-secured-data-warehouse/v0.1.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -55,7 +55,3 @@ terraform {
   }
 
 }
-
-locals {
-  blueprint_type = "blueprints/terraform/terraform-google-secured-data-warehouse/v1.0.0"
-}


### PR DESCRIPTION
Hardcodes blueprint type per discussion in https://github.com/GoogleCloudPlatform/terraform-google-secured-data-warehouse/pull/207.  b/209714727 for future automation.
closes https://github.com/GoogleCloudPlatform/terraform-google-secured-data-warehouse/pull/207