### PR TITLE
Fix: Set key helper key length to 32 bytes

### DIFF
--- a/helpers/wrapped-key/README.md
+++ b/helpers/wrapped-key/README.md
@@ -41,6 +41,8 @@ source kms_helper/bin/activate
 ### Install dependencies
 
 ```sh
+pip install --upgrade pip
+
 pip install -r requirements.txt
 ```
 

--- a/helpers/wrapped-key/wrapped_key.py
+++ b/helpers/wrapped-key/wrapped_key.py
@@ -35,10 +35,7 @@ def encrypt_symmetric(project_id, location_id, key_ring_id, key_id):
     """
 
     # Generate random bytes
-    key = generate_random_bytes(project_id, location_id, 16)
-
-    # Encode key to b64
-    plaintext_bytes = base64.b64encode(key)
+    plaintext_bytes = generate_random_bytes(project_id, location_id, 32)
 
     # Optional, but recommended: compute plaintext's CRC32C.
     # See crc32c() function defined below.


### PR DESCRIPTION
This PR set the key length of the wrapped key to 32 bytes (256 bits) of random data generated by Cloud KMS `GenerateRandomBytes` service.

Fixes #254
 
- [x] Tests pass
- [x] Appropriate changes to README are included in PR
