### PR TITLE
fix: Pin the version of the bridge_service_perimeter

### DIFF
--- a/service_control.tf
+++ b/service_control.tf
@@ -277,7 +277,7 @@ resource "google_access_context_manager_service_perimeter_resource" "confidentia
 
 module "vpc_sc_bridge_data_ingestion_governance" {
   source  = "terraform-google-modules/vpc-service-controls/google//modules/bridge_service_perimeter"
-  version = "~> 3.0"
+  version = "3.1"
 
   policy         = local.actual_policy
   perimeter_name = "vpc_sc_bridge_data_ingestion_governance_${random_id.suffix.hex}"
@@ -301,7 +301,7 @@ module "vpc_sc_bridge_data_ingestion_governance" {
 
 module "vpc_sc_bridge_confidential_governance" {
   source  = "terraform-google-modules/vpc-service-controls/google//modules/bridge_service_perimeter"
-  version = "~> 3.0"
+  version = "3.1"
 
   policy         = local.actual_policy
   perimeter_name = "vpc_sc_bridge_confidential_governance_${random_id.suffix.hex}"
@@ -323,7 +323,7 @@ module "vpc_sc_bridge_confidential_governance" {
 
 module "vpc_sc_bridge_confidential_data_ingestion" {
   source  = "terraform-google-modules/vpc-service-controls/google//modules/bridge_service_perimeter"
-  version = "~> 3.0"
+  version = "3.1"
 
   policy         = local.actual_policy
   perimeter_name = "vpc_sc_bridge_confidential_data_ingestion_${random_id.suffix.hex}"


### PR DESCRIPTION
Fixes #267

Pin the version of the bridge_service_perimeter to avoid the `for_each` error in the new version of bridge_service_perimeter.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
