### PR TITLE
fix: waits iam policies propagates before submit builds

### DIFF
--- a/test/setup/template-project/main.tf
+++ b/test/setup/template-project/main.tf
@@ -151,7 +151,8 @@ EOF
   }
 
   depends_on = [
-    module.external_flex_template_infrastructure
+    module.external_flex_template_infrastructure,
+    time_sleep.wait_60_seconds
   ]
 }
 
@@ -179,7 +180,8 @@ EOF
   }
 
   depends_on = [
-    module.external_flex_template_infrastructure
+    module.external_flex_template_infrastructure,
+    time_sleep.wait_60_seconds
   ]
 }
 
@@ -207,6 +209,7 @@ EOF
   }
 
   depends_on = [
-    module.external_flex_template_infrastructure
+    module.external_flex_template_infrastructure,
+    time_sleep.wait_60_seconds
   ]
 }


### PR DESCRIPTION
Fixes the error happening in the prepare step, where gcloud builds submit fails due a propagation issue.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
