### PR TITLE
test: bumps image to 1.14.4

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -170,7 +170,7 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.14'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.14.4'
 options:
   machineType: 'N1_HIGHCPU_8'
   env:


### PR DESCRIPTION
Tests dev-tools 1.14.4 version with ruby tests

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
